### PR TITLE
首届996优秀项目大赛邀请函

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ## yet another overtime corps list
 [![996.icu](https://img.shields.io/badge/link-996.icu-red.svg)](https://996.icu)
 [![LICENSE](https://img.shields.io/badge/license-Anti%20996-blue.svg)](https://github.com/996icu/996.ICU/blob/master/LICENSE)
+[![top.996](https://img.shields.io/badge/link-top.996-red.svg)](https://github.com/top996/top.996)
 
 本项目开源,采用Anti 996协议开源
 


### PR DESCRIPTION
首届996优秀项目大赛，投票截止日期为2019年7月1日，7月10日公布最终比赛结果。 大赛选取了目前github上各个反996热门项目，大赛前三名将获得对应的项目发展支持基金。 一等奖人民币5000元，二等奖人民币3000元，三等奖人民币1000元，四到六名纪念奖人民币300元。
添加徽章加站长微信群就送50元报名红包。
[站长请加微信群](https://github.com/top996/top.996)